### PR TITLE
Add bilingual support with i18n

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,11 @@
+{
+  "nav": {
+    "home": "Home",
+    "settings": "Settings",
+    "contact": "Contact",
+    "account": "Account"
+  },
+  "footer": {
+    "designedBy": "Designed by"
+  }
+}

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -1,0 +1,11 @@
+{
+  "nav": {
+    "home": "Anasayfa",
+    "settings": "Ayarlar",
+    "contact": "İletişim",
+    "account": "Hesabım"
+  },
+  "footer": {
+    "designedBy": "Tasarlayan"
+  }
+}

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -107,8 +107,11 @@ section {
 }
 
 body {
-	line-height: 1;
-	overflow-x: hidden;
+        line-height: 1;
+        overflow-x: hidden;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
 }
 
 menu,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import styles from "@/styles/Main.module.scss";
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import Providers from "@/components/Providers";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -19,13 +20,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="tr">
       <body className={inter.className}>
-        <Header/>
-        <div className={styles.container}>
-          {children}
-        </div>
-        <Footer/>
+        <Providers>
+          <Header />
+          <div className={styles.container}>{children}</div>
+          <Footer />
+        </Providers>
       </body>
     </html>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import styles from "@/styles/Footer.module.scss";
 import Link from "next/link";
+import { useTranslation } from "react-i18next";
 
 export default function Footer() {
+  const { t } = useTranslation('common');
   return (
     <footer className={styles.footer}>
       <div className={styles.container}>
@@ -15,22 +17,22 @@ export default function Footer() {
               <ul className={styles.footer__navList}>
                 <li className={styles.footer__navItem}>
                   <Link href="/dashboard" className={styles.footer__navLink}>
-                    Anasayfa
+                    {t('nav.home')}
                   </Link>
                 </li>
                 <li className={styles.footer__navItem}>
                   <Link href="/services" className={styles.footer__navLink}>
-                    Ayarlar
+                    {t('nav.settings')}
                   </Link>
                 </li>
                 <li className={styles.footer__navItem}>
                   <Link href="/contact" className={styles.footer__navLink}>
-                    İletişim
+                    {t('nav.contact')}
                   </Link>
                 </li>
                 <li className={styles.footer__navItem}>
                   <Link href="/profile" className={styles.footer__navLink}>
-                    Hesabım
+                    {t('nav.account')}
                   </Link>
                 </li>
               </ul>
@@ -89,7 +91,7 @@ export default function Footer() {
         </div>
         <div className={styles.footer__copyrights}>
           <p>
-            Tasarlayan
+            {t('footer.designedBy')}
             <Link href="https://hasimkilicdev.vercel.app/" target="_blank">
               HaşimK
             </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,11 +3,14 @@ import React, { useState } from "react";
 import styles from "@/styles/Header.module.scss";
 import Link from "next/link";
 import Image from "next/image";
+import { useTranslation } from "react-i18next";
 import darkModeIcon from "../../public/darkMode.svg";
 import lightModeIcon from "../../public/lightMode.svg";
+import LanguageSwitcher from "./LanguageSwitcher";
 
 export default function Header() {
   const [isDarkMode, setIsDarkMode] = useState(false);
+  const { t } = useTranslation('common');
 
   const toggleDarkMode = () => {
     setIsDarkMode(!isDarkMode);
@@ -34,13 +37,13 @@ export default function Header() {
           </button>
           <ul className={styles.navWrapper}>
             <li className={styles.navItem}>
-              <Link href="/dashboard">Anasayfa</Link>
+              <Link href="/dashboard">{t('nav.home')}</Link>
             </li>
             <li className={styles.navItem}>
-              <Link href="/services">Ayarlar</Link>
+              <Link href="/services">{t('nav.settings')}</Link>
             </li>
             <li className={styles.navItem}>
-              <Link href="/contact">İletişim</Link>
+              <Link href="/contact">{t('nav.contact')}</Link>
             </li>
           </ul>
         </nav>
@@ -59,8 +62,9 @@ export default function Header() {
             />
           </button>
           <Link href="/profile" className={styles.navItem}>
-            Hesabım
+            {t('nav.account')}
           </Link>
+          <LanguageSwitcher />
         </div>
       </div>
     </header>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,17 @@
+'use client';
+import i18n from '@/i18n';
+
+export default function LanguageSwitcher() {
+  const changeLanguage = (lng: string) => {
+    i18n.changeLanguage(lng);
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = lng;
+    }
+  };
+  return (
+    <div style={{ display: 'flex', gap: '0.5rem' }}>
+      <button onClick={() => changeLanguage('tr')}>TR</button>
+      <button onClick={() => changeLanguage('en')}>EN</button>
+    </div>
+  );
+}

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,0 +1,7 @@
+'use client';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '@/i18n';
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,21 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import HttpBackend from 'i18next-http-backend';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+i18n
+  .use(HttpBackend)
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    fallbackLng: 'tr',
+    supportedLngs: ['tr', 'en'],
+    interpolation: {
+      escapeValue: false,
+    },
+    backend: {
+      loadPath: '/locales/{{lng}}/{{ns}}.json',
+    },
+  });
+
+export default i18n;

--- a/src/styles/Main.module.scss
+++ b/src/styles/Main.module.scss
@@ -10,6 +10,7 @@ $color-primary: #1f2a38;
   width: 100%;
   margin: 0 auto;
   padding: 1.5rem 3rem;
+  flex: 1;
 }
 
 .title {


### PR DESCRIPTION
## Summary
- configure i18next with English and Turkish translations
- add language switcher and provider components
- update header and footer to use translated strings
- wrap app with provider for translations

## Testing
- `npm run lint` *(fails: `next` not found)*